### PR TITLE
feat: add message and ref outputs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,6 +62,7 @@ jobs:
           script: |
             const assert = require('node:assert');
 
+            const message = 'Test new ref commit';
             const refs = ['integration-test-playground-${{ github.run_id }}-${{ github.run_number }}', '${{ steps.commit-new-ref.outputs.sha }}'];
 
             // Fetch the commit by both ref and sha
@@ -69,12 +70,14 @@ jobs:
               const { data } = await github.rest.repos.getCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: 'integration-test-playground-${{ github.run_id }}-${{ github.run_number }}',
+                ref,
               });
 
+              assert.strictEqual('${{ steps.commit-new-ref.outputs.message }}', message, 'Expected correct message output');
+              assert.strictEqual('${{ steps.commit-new-ref.outputs.ref }}', refs[0], 'Expected correct ref output');
               assert.strictEqual('${{ steps.commit-new-ref.outputs.ref-operation }}', 'created', 'Expected correct ref operation');
               assert.strictEqual(data.sha, '${{ steps.commit-new-ref.outputs.sha }}', 'Expected sha for commit to match');
-              assert.strictEqual(data.commit.message, 'Test new ref commit', 'Expected commit message to match');
+              assert.strictEqual(data.commit.message, message, 'Expected commit message to match');
               assert.strictEqual(data.commit.verification.verified, true, 'Expected commit to be verified');
             }
 
@@ -107,6 +110,7 @@ jobs:
           script: |
             const assert = require('node:assert');
 
+            const message = 'Test updating existing ref';
             const refs = ['integration-test-playground-${{ github.run_id }}-${{ github.run_number }}', '${{ steps.update-existing-ref.outputs.sha }}'];
 
             // Fetch the commit by both ref and sha
@@ -114,12 +118,14 @@ jobs:
               const { data } = await github.rest.repos.getCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: 'integration-test-playground-${{ github.run_id }}-${{ github.run_number }}',
+                ref,
               });
 
+              assert.strictEqual('${{ steps.update-existing-ref.outputs.message }}', message, 'Expected correct message output');
+              assert.strictEqual('${{ steps.update-existing-ref.outputs.ref }}', refs[0], 'Expected correct ref output');
               assert.strictEqual('${{ steps.update-existing-ref.outputs.ref-operation }}', 'updated', 'Expected correct ref operation');
               assert.strictEqual(data.sha, '${{ steps.update-existing-ref.outputs.sha }}', 'Expected sha for commit to match');
-              assert.strictEqual(data.commit.message, 'Test updating existing ref', 'Expected commit message to match');
+              assert.strictEqual(data.commit.message, message, 'Expected commit message to match');
               assert.strictEqual(data.commit.verification.verified, true, 'Expected commit to be verified');
             }
 
@@ -146,6 +152,7 @@ jobs:
           script: |
             const assert = require('node:assert');
 
+            const message = 'Test updating existing ref (again)';
             const refs = ['integration-test-playground-${{ github.run_id }}-${{ github.run_number }}', '${{ steps.update-existing-ref-2.outputs.sha }}'];
 
             // Fetch the commit by both ref and sha
@@ -153,12 +160,14 @@ jobs:
               const { data } = await github.rest.repos.getCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: 'integration-test-playground-${{ github.run_id }}-${{ github.run_number }}',
+                ref,
               });
 
+              assert.strictEqual('${{ steps.update-existing-ref-2.outputs.message }}', message, 'Expected correct message output');
+              assert.strictEqual('${{ steps.update-existing-ref-2.outputs.ref }}', refs[0], 'Expected correct ref output');
               assert.strictEqual('${{ steps.update-existing-ref-2.outputs.ref-operation }}', 'updated', 'Expected correct ref operation');
               assert.strictEqual(data.sha, '${{ steps.update-existing-ref-2.outputs.sha }}', 'Expected sha for commit to match');
-              assert.strictEqual(data.commit.message, 'Test updating existing ref (again)', 'Expected commit message to match');
+              assert.strictEqual(data.commit.message, message, 'Expected commit message to match');
               assert.strictEqual(data.commit.verification.verified, true, 'Expected commit to be verified');
             }
 
@@ -200,6 +209,7 @@ jobs:
           script: |
             const assert = require('node:assert');
 
+            const message = 'Test updating existing ref (force)';
             const refs = ['integration-test-playground-${{ github.run_id }}-${{ github.run_number }}', '${{ steps.force-update-existing-ref.outputs.sha }}'];
 
             // Fetch the commit by both ref and sha
@@ -207,12 +217,14 @@ jobs:
               const { data } = await github.rest.repos.getCommit({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: 'integration-test-playground-${{ github.run_id }}-${{ github.run_number }}',
+                ref,
               });
 
+              assert.strictEqual('${{ steps.force-update-existing-ref.outputs.message }}', message, 'Expected correct message output');
+              assert.strictEqual('${{ steps.force-update-existing-ref.outputs.ref }}', refs[0], 'Expected correct ref output');
               assert.strictEqual('${{ steps.force-update-existing-ref.outputs.ref-operation }}', 'updated', 'Expected correct ref operation');
               assert.strictEqual(data.sha, '${{ steps.force-update-existing-ref.outputs.sha }}', 'Expected sha for commit to match');
-              assert.strictEqual(data.commit.message, 'Test updating existing ref (force)', 'Expected commit message to match');
+              assert.strictEqual(data.commit.message, message, 'Expected commit message to match');
               assert.strictEqual(data.commit.verification.verified, true, 'Expected commit to be verified');
             }
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ jobs:
 
 ### Outputs
 
+- `message` - The commit message
+- `ref` - The associated Git reference
 - `ref-operation` - Which operation was performed on the ref: `created` or `updated`. Has no value if there were no changes to commit.
 - `sha` - SHA for the commit
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -131,7 +131,9 @@ describe('action', () => {
       })
     );
 
-    expect(core.setOutput).toHaveBeenCalledTimes(2);
+    expect(core.setOutput).toHaveBeenCalledTimes(4);
+    expect(core.setOutput).toHaveBeenCalledWith('message', message);
+    expect(core.setOutput).toHaveBeenCalledWith('ref', ref);
     expect(core.setOutput).toHaveBeenCalledWith('ref-operation', 'updated');
     expect(core.setOutput).toHaveBeenCalledWith('sha', commitSha);
   });
@@ -173,7 +175,9 @@ describe('action', () => {
       })
     );
 
-    expect(core.setOutput).toHaveBeenCalledTimes(2);
+    expect(core.setOutput).toHaveBeenCalledTimes(4);
+    expect(core.setOutput).toHaveBeenCalledWith('message', message);
+    expect(core.setOutput).toHaveBeenCalledWith('ref', ref);
     expect(core.setOutput).toHaveBeenCalledWith('ref-operation', 'updated');
     expect(core.setOutput).toHaveBeenCalledWith('sha', commitSha);
   });
@@ -198,7 +202,9 @@ describe('action', () => {
     expect(updateRef).toHaveBeenCalled();
     expect(createRef).not.toHaveBeenCalled();
 
-    expect(core.setOutput).toHaveBeenCalledTimes(2);
+    expect(core.setOutput).toHaveBeenCalledTimes(4);
+    expect(core.setOutput).toHaveBeenCalledWith('message', message);
+    expect(core.setOutput).toHaveBeenCalledWith('ref', ref);
     expect(core.setOutput).toHaveBeenCalledWith('ref-operation', 'updated');
     expect(core.setOutput).toHaveBeenCalledWith('sha', commitSha);
   });
@@ -241,7 +247,9 @@ describe('action', () => {
       })
     );
 
-    expect(core.setOutput).toHaveBeenCalledTimes(2);
+    expect(core.setOutput).toHaveBeenCalledTimes(4);
+    expect(core.setOutput).toHaveBeenCalledWith('message', message);
+    expect(core.setOutput).toHaveBeenCalledWith('ref', ref);
     expect(core.setOutput).toHaveBeenCalledWith('ref-operation', 'created');
     expect(core.setOutput).toHaveBeenCalledWith('sha', commitSha);
   });
@@ -327,7 +335,9 @@ describe('action', () => {
     );
     expect(createRef).not.toHaveBeenCalled();
 
-    expect(core.setOutput).toHaveBeenCalledTimes(2);
+    expect(core.setOutput).toHaveBeenCalledTimes(4);
+    expect(core.setOutput).toHaveBeenCalledWith('message', message);
+    expect(core.setOutput).toHaveBeenCalledWith('ref', ref);
     expect(core.setOutput).toHaveBeenCalledWith('ref-operation', 'updated');
     expect(core.setOutput).toHaveBeenCalledWith('sha', commitSha);
   });

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     required: true
 
 outputs:
+  message:
+    description: The commit message
+  ref:
+    description: The associated Git reference
   ref-operation:
     description: 'Which operation was performed on the ref: `created` or `updated`. Has no value if there were no changes to commit.'
   sha:

--- a/dist/index.js
+++ b/dist/index.js
@@ -30364,7 +30364,7 @@ async function run() {
         const message = core.getInput('message', { required: true });
         const token = core.getInput('token', { required: true });
         // Optional inputs
-        const ref = `heads/${core.getInput('ref') || (await (0, lib_1.getHeadRef)())}`;
+        const ref = core.getInput('ref') || (await (0, lib_1.getHeadRef)());
         const failOnNoChanges = core.getBooleanInput('fail-on-no-changes');
         const force = core.getBooleanInput('force');
         const tree = await populateTree();
@@ -30399,7 +30399,7 @@ async function run() {
             await octokit.rest.git.updateRef({
                 owner,
                 repo,
-                ref,
+                ref: `heads/${ref}`,
                 sha: newCommit.data.sha,
                 force
             });
@@ -30413,7 +30413,7 @@ async function run() {
                 await octokit.rest.git.createRef({
                     owner,
                     repo,
-                    ref: `refs/${ref}`,
+                    ref: `refs/heads/${ref}`,
                     sha: newCommit.data.sha
                 });
                 core.setOutput('ref-operation', 'created');
@@ -30423,6 +30423,8 @@ async function run() {
                 throw err;
             }
         }
+        core.setOutput('message', message);
+        core.setOutput('ref', ref);
         core.setOutput('sha', newCommit.data.sha);
     }
     catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ export async function run(): Promise<void> {
     const token = core.getInput('token', { required: true });
 
     // Optional inputs
-    const ref = `heads/${core.getInput('ref') || (await getHeadRef())}`;
+    const ref = core.getInput('ref') || (await getHeadRef());
     const failOnNoChanges = core.getBooleanInput('fail-on-no-changes');
     const force = core.getBooleanInput('force');
 
@@ -105,7 +105,7 @@ export async function run(): Promise<void> {
       await octokit.rest.git.updateRef({
         owner,
         repo,
-        ref,
+        ref: `heads/${ref}`,
         sha: newCommit.data.sha,
         force
       });
@@ -120,7 +120,7 @@ export async function run(): Promise<void> {
         await octokit.rest.git.createRef({
           owner,
           repo,
-          ref: `refs/${ref}`,
+          ref: `refs/heads/${ref}`,
           sha: newCommit.data.sha
         });
         core.setOutput('ref-operation', 'created');
@@ -130,6 +130,8 @@ export async function run(): Promise<void> {
       }
     }
 
+    core.setOutput('message', message);
+    core.setOutput('ref', ref);
     core.setOutput('sha', newCommit.data.sha);
   } catch (error) {
     // Fail the workflow run if an error occurs


### PR DESCRIPTION
Useful to mirror the inputs so that if the inputs were generated strings the user can more easily chain actions.